### PR TITLE
Remove whitespace around button stories

### DIFF
--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -6,10 +6,6 @@ import { Button } from './Button';
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
   component: Button,
-  parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-    layout: 'centered',
-  },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes


### PR DESCRIPTION
This ended up not looking great in happo so I'm using the default "padded" layout instead.