### PR TITLE
Fix styling of Header on small screens

### DIFF
--- a/src/stories/button.css
+++ b/src/stories/button.css
@@ -20,7 +20,7 @@
 .storybook-button--small {
   padding: 10px 16px;
   font-size: 12px;
-  min-width: 150px;
+  min-width: auto;
 }
 .storybook-button--medium {
   padding: 11px 20px;

--- a/src/stories/header.css
+++ b/src/stories/header.css
@@ -19,6 +19,10 @@
   font-weight: 700;
   font-size: 20px;
   line-height: 1;
+
+  @media (max-width: 600px) {
+    display: none;
+  }
 }
 
 .storybook-header button + button {


### PR DESCRIPTION
The component's content was wrapping weirdly. Fixed by making buttons smaller and removing the "Showcase" text on small screens.